### PR TITLE
Support getOwner() with no arguments in plain function helpers

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/default-helper-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/default-helper-manager-test.js
@@ -4,6 +4,7 @@ import { Component } from '@ember/-internals/glimmer';
 import { precompileTemplate } from '@ember/template-compilation';
 import { set } from '@ember/object';
 import { action } from '@ember/object';
+import { getOwner } from '@ember/owner';
 
 moduleFor(
   'Helpers test: default helper manager',
@@ -167,6 +168,55 @@ moduleFor(
 
       this.render(`<FooBar />`);
       this.assertText('hello');
+    }
+
+    '@test getOwner() with no arguments returns the owner inside a plain function helper'(assert) {
+      let captured = 'NOT_SET';
+
+      function whoOwnsMe() {
+        captured = getOwner();
+        return 'rendered';
+      }
+
+      this.render('{{(this.whoOwnsMe)}}', { whoOwnsMe });
+
+      this.assertText('rendered');
+      assert.strictEqual(captured, this.owner, 'getOwner() returned the rendering owner');
+    }
+
+    '@test getOwner() with no arguments works in a function helper passed as an argument'(assert) {
+      let captured = 'NOT_SET';
+
+      function whoOwnsMe() {
+        captured = getOwner();
+        return 'rendered';
+      }
+
+      this.owner.register(
+        'component:foo-bar',
+        setComponentTemplate(precompileTemplate('{{(@whoOwnsMe)}}'), class extends Component {})
+      );
+
+      this.render(`<FooBar @whoOwnsMe={{this.whoOwnsMe}} />`, { whoOwnsMe });
+
+      this.assertText('rendered');
+      assert.strictEqual(captured, this.owner, 'getOwner() returned the rendering owner');
+    }
+
+    '@test getOwner() is undefined outside a helper and the ambient is restored afterward'(assert) {
+      assert.strictEqual(getOwner(), undefined, 'no ambient owner before rendering');
+
+      let captured = 'NOT_SET';
+      let whoOwnsMe = () => {
+        captured = getOwner();
+        return 'rendered';
+      };
+
+      this.render('{{(this.whoOwnsMe)}}', { whoOwnsMe });
+      this.assertText('rendered');
+
+      assert.strictEqual(captured, this.owner, 'the helper saw the rendering owner');
+      assert.strictEqual(getOwner(), undefined, 'ambient owner cleared again after the helper ran');
     }
   }
 );

--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -1,4 +1,5 @@
 import { getOwner as glimmerGetOwner, setOwner as glimmerSetOwner } from '@glimmer/owner';
+import { OWNER as OWNER_CONTEXT, lookupRenderContext } from '@glimmer/runtime/lib/render-scope';
 
 /**
   @module @ember/owner
@@ -539,7 +540,14 @@ export function isFactory(obj: unknown): obj is InternalFactory<object> {
 // NOTE: For docs, see the definition at the public API site in `@ember/owner`;
 // we document it there for the sake of public API docs and for TS consumption,
 // while having the richer `InternalOwner` representation for Ember itself.
-export function getOwner(object: object): InternalOwner | undefined {
+export function getOwner(object?: object): InternalOwner | undefined {
+  // With no argument, read the owner from the render tree -- it is provided as a
+  // context by the helper opcode, so `getOwner()` works inside a plain function
+  // helper (which has no `this`) and walks up the tree like any context.
+  if (object === undefined) {
+    let read = lookupRenderContext(OWNER_CONTEXT);
+    return read ? (read() as InternalOwner | undefined) : undefined;
+  }
   // SAFETY: this is a convention. From the glimmer perspective, the owner really can be any object.
   return glimmerGetOwner(object) as InternalOwner;
 }

--- a/packages/@ember/owner/index.ts
+++ b/packages/@ember/owner/index.ts
@@ -72,10 +72,28 @@ import { type default as Owner, getOwner as internalGetOwner } from '@ember/-int
   }
   ```
 
+  `getOwner` may also be called with no argument from inside a plain function
+  helper, where there is no `this` to read the owner from. While the helper is
+  rendering, it returns the owner the helper was invoked with:
+
+  ```js
+  import { getOwner } from '@ember/owner';
+
+  function currentLocale() {
+    return getOwner()?.lookup('service:intl').locale;
+  }
+
+  // Usage: {{ (currentLocale) }}
+  ```
+
+  Outside of a plain function helper's invocation, the no-argument form returns
+  `undefined`.
+
   @method getOwner
   @static
   @for @ember/owner
-  @param {Object} object An object with an owner.
+  @param {Object} [object] An object with an owner. When omitted, the ambient
+    owner of the currently-rendering plain function helper is returned.
   @return {Object} An owner object.
   @since 2.3.0
   @public
@@ -84,7 +102,7 @@ import { type default as Owner, getOwner as internalGetOwner } from '@ember/-int
 // TS (not incorrectly! Nothing expressly relates them) does not see that the
 // `InternalOwner` and `Owner` do actually have identical constraints on their
 // relations to the `DIRegistry`.
-const getOwner = internalGetOwner as (object: object) => Owner | undefined;
+const getOwner = internalGetOwner as (object?: object) => Owner | undefined;
 export { getOwner };
 
 // Everything else which is part of the public API, we can directly re-export.

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -56,6 +56,7 @@ import { $v0 } from '@glimmer/vm/lib/registers';
 
 import { isCurriedType, resolveCurriedValue } from '../../curried-value';
 import { APPEND_OPCODES } from '../../opcodes';
+import { OWNER, provideRenderContext } from '../../render-scope';
 import createCurryRef from '../../references/curry-value';
 import { reifyPositional } from '../../vm/arguments';
 import { createConcatRef } from '../expressions/concat';
@@ -99,6 +100,10 @@ APPEND_OPCODES.add(VM_DYNAMIC_HELPER_OP, (vm) => {
 
   let helperRef: Initializable<Reference>;
   let initialOwner = vm.getOwner();
+  // RFC #1154 -- provide the owner as a context on the current render node so
+  // `getOwner()` (no argument) works inside this helper (and walks up the tree
+  // like any context). This is the dynamic path (e.g. `{{(this.helper)}}`).
+  provideRenderContext(OWNER, () => initialOwner);
 
   let helperInstanceRef = createComputeRef(() => {
     if (helperRef !== undefined) {
@@ -176,7 +181,12 @@ APPEND_OPCODES.add(VM_HELPER_OP, (vm, { op1: handle }) => {
   let stack = vm.stack;
   let helper = check(vm.constants.getValue(handle), CheckHelper);
   let args = check(stack.pop(), CheckArguments);
-  let value = helper(args.capture(), vm.getOwner(), vm.dynamicScope());
+  let owner = vm.getOwner();
+  // RFC #1154 -- provide the owner as a context on the current render node so
+  // `getOwner()` (no argument) works inside this helper (and walks up the tree
+  // like any context). This is the static path; see VM_DYNAMIC_HELPER_OP too.
+  provideRenderContext(OWNER, () => owner);
+  let value = helper(args.capture(), owner, vm.dynamicScope());
 
   if (_hasDestroyableChildren(value)) {
     vm.associateDestroyable(value);

--- a/packages/@glimmer/runtime/lib/render-scope.ts
+++ b/packages/@glimmer/runtime/lib/render-scope.ts
@@ -12,6 +12,11 @@ interface RenderScopeNode {
   contexts: Nullable<Map<object, ContextRead>>;
 }
 
+// A well-known context key under which the active owner is provided (see the
+// helper opcodes). The owner is just a context, so `getOwner()` reuses the same
+// provide/lookup machinery and walks up the render tree exactly like `consume()`.
+export const OWNER: object = {};
+
 /**
  * Tracks the render-tree node hierarchy so a consumer can find the nearest
  * provider above it. Mirrors `DebugRenderTree`'s stack management, but is

--- a/type-tests/@ember/application-test/index.ts
+++ b/type-tests/@ember/application-test/index.ts
@@ -18,8 +18,9 @@ declare class MyService extends Service {
 declare let myService: MyService;
 expectTypeOf(getOwner(myService)).toEqualTypeOf<Owner | undefined>();
 
-// @ts-expect-error
-getOwner();
+// The no-argument form returns the ambient owner (e.g. inside a plain function
+// helper), so it is valid and yields `Owner | undefined`.
+expectTypeOf(getOwner()).toEqualTypeOf<Owner | undefined>();
 
 declare let baseOwner: Owner;
 expectTypeOf(setOwner({}, baseOwner)).toBeVoid();

--- a/type-tests/@ember/owner-tests.ts
+++ b/type-tests/@ember/owner-tests.ts
@@ -184,6 +184,9 @@ class ExampleComponent<T> extends Component<Sig<T>> {
 declare let example: ExampleComponent<string>;
 expectTypeOf(getOwner(example)).toEqualTypeOf<Owner | undefined>();
 
+// The no-argument form (ambient owner, e.g. inside a plain function helper).
+expectTypeOf(getOwner()).toEqualTypeOf<Owner | undefined>();
+
 // ----- Minimal further coverage for POJOs ----- //
 // `Factory` and `FactoryManager` don't have to deal in actual classes. :sigh:
 const Creatable = {


### PR DESCRIPTION
## Summary

Adds a **no-argument** form of `getOwner()` that works inside a helper (notably a plain function helper).

`getOwner(obj)` reads the owner off an owned object — but a plain function helper has no `this` (or any owned object) to hand it. With this change:

```js
import { getOwner } from '@ember/owner';

function currentLocale() {
  return getOwner()?.lookup('service:intl').locale;
}

// {{ (currentLocale) }}
```

`getOwner()` (no arg) returns the owner the helper is being rendered with. Outside of rendering it returns `undefined`.

## How it works

The owner is modeled as a **context** (RFC #1154's render-scope tracker) — not a separate mechanism. At the point a helper is invoked — the helper opcodes (`VM_HELPER_OP` and `VM_DYNAMIC_HELPER_OP`), where `vm.getOwner()` is known — the owner is *provided* on the current render node under a well-known `OWNER` key, using the same `provideRenderContext` that `makeContext`'s `<Provide>` uses. `getOwner()` with no argument reads it back with `lookupRenderContext`.

Two consequences fall out of reusing the context machinery:

- **One mechanism.** There's no parallel owner storage or set/get — just an exported `OWNER` key plus the existing `provideRenderContext` / `lookupRenderContext`. The render-scope tracker is otherwise unchanged.
- **It walks up the render tree exactly like `consume()`**, since it *is* a context lookup.

Storing it in the render tree (rather than a transient ambient around the call) also means it resolves correctly on re-render, where a helper's lazily-computed reference re-runs but the opcode does not.

Changes:

- `@glimmer/runtime/lib/render-scope`: export an `OWNER` context key.
- helper opcodes: `provideRenderContext(OWNER, () => owner)` before invoking the helper.
- `@ember/-internals/owner` + `@ember/owner`: `getOwner` accepts no argument and reads the owner context.

## Tests

- **Runtime** (`default-helper-manager-test.js`): the owner is returned inside a plain function helper, inside a function helper passed as an `@arg`, and `getOwner()` is `undefined` outside a helper.
- **Types** (`type-tests/@ember/owner-tests.ts`, `application-test`): the no-arg signature returns `Owner | undefined` (the previous `// @ts-expect-error getOwner()` is replaced with a positive assertion).

## Validation

- `type-check:internals` clean.
- `pnpm build:js` + `build:types` succeed.
- `lint:eslint` / `lint:format` / `lint:docs` clean.
- `default-helper-manager` (21/21) and `makeContext` (23/23) browser suites pass.

## Notes

- Stacked on the `makeContext` branch — this reuses its render-scope tracker, which is exactly where per-render-node ambient state belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
